### PR TITLE
Fix : UserRoutineCollectionRepository 의 쿼리 파라미터 수정 및 설정 리팩토링

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ application-oauth.yml
 TestDatainit.java
 src/main/generated/
 daitgym-firebase-sdk.json
+/src/main/resources/application-cloud.yml
+/src/main/resources/application-db.yml
+/src/main/resources/application-local_db.yml

--- a/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/UserRoutineCollectionRepository.java
@@ -21,10 +21,10 @@ public interface UserRoutineCollectionRepository extends JpaRepository<UserRouti
     long countByRoutineId(@Param("routineId") Long routineId);
 
     @Query("SELECT urc.routine.id FROM UserRoutineCollection urc WHERE urc.user.email = :email")
-    Set<Long> findScrappedRoutineIdByUserEmail(String email);
+    Set<Long> findScrappedRoutineIdByUserEmail(@Param("email") String email);
 
     @Query("SELECT urc.routine.id FROM UserRoutineCollection urc WHERE urc.user.nickname = :nickname")
-    Set<Long> findScrappedRoutineIdByUserNickname(String nickname);
+    Set<Long> findScrappedRoutineIdByUserNickname(@Param("nickname") String nickname);
 
     boolean existsByUserEmailAndRoutineId(String userEmail, Long routineId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,13 @@
 spring:
   profiles:
-    include:
-      - dev
-      - oauth
+    active: local
+    group:
+      local:
+        - local_db
+        - cloud
+        - oauth
+      dev:
+        - db
+        - cloud
+        - oauth
+      prod:


### PR DESCRIPTION
## UserRoutineCollectionRepository 의 쿼리 파라미터 수정
- `@Param` 어노테이션을 사용하여 String 파라미터를 받도록 indScrappedRoutineIdByUserEmail과  findScrappedRoutineIdByUserNickname 메서드의 쿼리 파라미터를 수정

## 프로필 구성 업데이트 및 gitignore 편집
- 프로필 구성을 세분화 및 gitignore에 추가
- 실행 환경에 맞게 local, dev, prod 그룹을 정의