### PR TITLE
Fix : 루틴 서비스의 예외 처리 코드 제거 및 Optional 제거

### DIFF
--- a/src/main/java/com/ogjg/daitgym/routine/repository/RoutineRepository.java
+++ b/src/main/java/com/ogjg/daitgym/routine/repository/RoutineRepository.java
@@ -13,13 +13,13 @@ import java.util.Optional;
 public interface RoutineRepository extends JpaRepository<Routine, Long>, RoutineRepositoryCustom {
 
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division)")
-    Optional<Slice<Routine>> findAllByDivision(@Param("division") Integer division, Pageable pageable);
+    Slice<Routine> findAllByDivision(@Param("division") Integer division, Pageable pageable);
 
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division) AND r.user.nickname = :nickname")
-    Optional<Slice<Routine>> findByDivisionAndUserNickname(@Param("division") Integer division, @Param("nickname") String nickname, Pageable pageable);
+    Slice<Routine> findByDivisionAndUserNickname(@Param("division") Integer division, @Param("nickname") String nickname, Pageable pageable);
 
     @Query("SELECT r FROM Routine r WHERE (:division IS NULL OR r.division = :division) AND r.user.email IN :followerEmails")
-    Optional<Slice<Routine>> findByDivisionAndUserEmailIn(@Param("division") Integer division, @Param("followerEmails") List<String> followerEmails, Pageable pageable);
+    Slice<Routine> findByDivisionAndUserEmailIn(@Param("division") Integer division, @Param("followerEmails") List<String> followerEmails, Pageable pageable);
 
 //    Optional<Routine> findById(Long routineId);
 

--- a/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
+++ b/src/main/java/com/ogjg/daitgym/routine/service/RoutineService.java
@@ -55,8 +55,7 @@ public class RoutineService {
     @Transactional(readOnly = true)
     public RoutineListResponseDto getRoutines(Pageable pageable, Integer division, String email) {
 
-        Slice<Routine> routines = routineRepository.findAllByDivision(division, pageable)
-                .orElseThrow(NotFoundRoutine::new);
+        Slice<Routine> routines = routineRepository.findAllByDivision(division, pageable);
 
         return getRoutineListResponseDto(routines, email);
     }
@@ -113,8 +112,7 @@ public class RoutineService {
 
     @Transactional(readOnly = true)
     public RoutineListResponseDto getUserRoutines(String nickname, Integer division, Pageable pageable) {
-        Slice<Routine> routines = routineRepository.findByDivisionAndUserNickname(division, nickname, pageable)
-                .orElseThrow(NotFoundRoutine::new);
+        Slice<Routine> routines = routineRepository.findByDivisionAndUserNickname(division, nickname, pageable);
 
         return getRoutineListResponseDto(routines, nickname);
     }
@@ -128,8 +126,7 @@ public class RoutineService {
                 .map(follow -> follow.getTarget().getEmail())
                 .toList();
 
-        Slice<Routine> routines = routineRepository.findByDivisionAndUserEmailIn(division, followingEmails, pageable)
-                .orElseThrow(NotFoundRoutine::new);
+        Slice<Routine> routines = routineRepository.findByDivisionAndUserEmailIn(division, followingEmails, pageable);
 
         return getRoutineListResponseDto(routines, myEmail);
     }


### PR DESCRIPTION
- 루틴 서비스에서 NotFoundRoutine 예외 처리 코드를 제거
- Slice는 이미 내부에 결과가 비어 있을 경우를 처리하기 때문에 Optional은 필요하지 않아 제거